### PR TITLE
fix: restrict AllPayAuction withdraw to auctioneer

### DIFF
--- a/contracts/AllPayAuction.sol
+++ b/contracts/AllPayAuction.sol
@@ -106,14 +106,23 @@ contract AllPayAuction is Auction {
 
     function withdraw(uint256 auctionId) external exists(auctionId) {
         AuctionData storage auction = auctions[auctionId];
+        require(msg.sender == auction.auctioneer, "Not auctioneer");
+
         uint256 withdrawAmount = auction.availableFunds;
+        require(withdrawAmount > 0, "No funds to withdraw");
+
         auction.availableFunds = 0;
+
         uint256 fees = (auction.protocolFee * withdrawAmount) / 10000;
         address feeRecipient = protocolParameters.treasury();
+
         sendERC20(auction.biddingToken, auction.auctioneer, withdrawAmount - fees);
-        sendERC20(auction.biddingToken,feeRecipient,fees);
+        sendERC20(auction.biddingToken, feeRecipient, fees);
+
         emit Withdrawn(auctionId, withdrawAmount);
     }
+
+
 
     function claim(uint256 auctionId) external exists(auctionId) onlyAfterDeadline(auctions[auctionId].deadline) notClaimed(auctions[auctionId].isClaimed) {
         AuctionData storage auction = auctions[auctionId];


### PR DESCRIPTION
Fixes #18
Adds access control to AllPayAuction.withdraw so only the auctioneer can withdraw funds.
Prevents unauthorized callers from triggering withdrawals.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restricted auction fund withdrawals to the auctioneer only.
  * Added protection against withdrawal attempts when no funds are available.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->