### PR TITLE
feat: enforce auction deadline for withdrawals and add related tests

### DIFF
--- a/contracts/AllPayAuction.sol
+++ b/contracts/AllPayAuction.sol
@@ -104,7 +104,7 @@ contract AllPayAuction is Auction {
         emit bidPlaced(auctionId, msg.sender, bids[auctionId][msg.sender]);
     }
 
-    function withdraw(uint256 auctionId) external exists(auctionId) {
+    function withdraw(uint256 auctionId) external exists(auctionId) onlyAfterDeadline(auctions[auctionId].deadline) {
         AuctionData storage auction = auctions[auctionId];
         uint256 withdrawAmount = auction.availableFunds;
         auction.availableFunds = 0;

--- a/package-lock.json
+++ b/package-lock.json
@@ -3134,20 +3134,6 @@
         "source-map": "~0.2.0"
       }
     },
-    "node_modules/escodegen/node_modules/source-map": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
-      "integrity": "sha512-CBdZ2oa/BHhS4xj5DlhjWNHcan57/5YuvfdLf17iVmIpd9KRm+DFLmC6nBNj+6Ua7Kt3TmOjDpQT1aTYOQtoUA==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "amdefine": ">=0.0.4"
-      },
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
     "node_modules/esprima": {
       "version": "2.7.3",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
@@ -6862,20 +6848,6 @@
       "peer": true,
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/uglify-js": {
-      "version": "3.19.3",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
-      "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "uglifyjs": "bin/uglifyjs"
-      },
-      "engines": {
-        "node": ">=0.8.0"
       }
     },
     "node_modules/undici": {


### PR DESCRIPTION
## Related Issue
Fixes #25 

## Description
This PR fixes a critical vulnerability in `AllPayAuction.sol` where the `withdraw()` function was missing deadline enforcement, allowing auctioneers to withdraw accumulated bid funds before the auction ended. This created a potential rug-pull vector and broke auction integrity.

The issue was identified through inconsistency analysis - `EnglishAuction` and `VickreyAuction` both properly enforce deadline checks on withdrawal, but `AllPayAuction` was missing this crucial validation.

## Changes

### Contract Updates
- **`contracts/AllPayAuction.sol` (Line 107)**
  - Added `onlyAfterDeadline(auctions[auctionId].deadline)` modifier to `withdraw()` function
  - Ensures withdrawal is only possible after `block.timestamp >= auction.deadline`
  - Aligns behavior with `EnglishAuction.sol` and `VickreyAuction.sol`

**Before:**
```solidity
function withdraw(uint256 auctionId) external exists(auctionId) { 
```

**After:**
```solidity
function withdraw(uint256 auctionId) external exists(auctionId) onlyAfterDeadline(auctions[auctionId].deadline) {```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Withdrawal operations now enforce deadline checks—withdrawals can only be completed after an auction's deadline passes.

* **Tests**
  * Added test coverage to verify deadline enforcement behavior for auction operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->