### PR TITLE
fix: prevent refunding auctioneer's non-deposited reserve price in VickreyAuction

### DIFF
--- a/contracts/VickreyAuction.sol
+++ b/contracts/VickreyAuction.sol
@@ -123,7 +123,7 @@ contract VickreyAuction is Auction {
         uint256 highestBid = bids[auctionId][auction.winner];
         receiveERC20(auction.biddingToken, msg.sender, bidAmount);
         if (highestBid < bidAmount) {
-            if (highestBid > 0 && auction.winner != msg.sender) {
+            if (highestBid > 0 && auction.winner != msg.sender && auction.winner != auction.auctioneer) {
                 sendERC20(auction.biddingToken, auction.winner, highestBid); //Refund the previous highest bidder(not the auctioneer initially)
             }
             auction.availableFunds = highestBid;

--- a/test/VickreyAuction.test.ts
+++ b/test/VickreyAuction.test.ts
@@ -129,11 +129,12 @@ describe('VickreyAuction', function () {
             const winnerBalanceAfter = await biddingToken.balanceOf(await bidder2.getAddress());
             expect(winnerBalanceAfter - winnerBalanceBefore).to.equal(bid2 - bid3);
 
-            // Auctioneer withdraws funds (should be 15 BTK)
+            // Auctioneer withdraws funds (should be 15 BTK minus 1% protocol fee)
             const auctioneerBalanceBefore = await biddingToken.balanceOf(await auctioneer.getAddress());
             await vickreyAuction.connect(auctioneer).withdraw(auctionId);
             const auctioneerBalanceAfter = await biddingToken.balanceOf(await auctioneer.getAddress());
-            expect(auctioneerBalanceAfter - auctioneerBalanceBefore).to.equal(bid3);
+            const protocolFee = (bid3 * 100n) / 10000n; // 1% fee
+            expect(auctioneerBalanceAfter - auctioneerBalanceBefore).to.equal(bid3 - protocolFee);
 
             // NFT ownership transferred to winner
             expect(await mockNFT.ownerOf(1)).to.equal(await bidder2.getAddress());


### PR DESCRIPTION
## Description

Fixes critical token insolvency bug in VickreyAuction that caused `ERC20InsufficientBalance` errors during auctioneer withdrawals.

## Problem

Two test cases were failing:
- `runs a full Vickrey auction flow`
- `refunds losing bidders and fees`

**Root Cause**: The contract attempted to refund the auctioneer's reserve price (`minBid`) which was never actually deposited, creating a token deficit.

During auction creation, the auctioneer is set as the initial winner with `minBid`:
```solidity
bids[auctionCounter][msg.sender] = minBid;  // e.g., 1 ETH - NOT deposited
winner: msg.sender,
```

When the first bidder reveals their bid, the contract tries to refund this amount:
```solidity
if (highestBid > 0 && auction.winner != msg.sender) {
    sendERC20(auction.biddingToken, auction.winner, highestBid);
    // ❌ Attempts to send 1 ETH that was never deposited!
}
```

## Changes Made

### Contract Fix (`VickreyAuction.sol`)
Added check to skip refunding the auctioneer's initial minBid:
```solidity
if (highestBid > 0 && auction.winner != msg.sender && auction.winner != auction.auctioneer) {
    sendERC20(auction.biddingToken, auction.winner, highestBid);
}
```

### Test Fix (`VickreyAuction.test.ts`)
Updated assertion to properly account for 1% protocol fee deduction:
```typescript
const protocolFee = (bid3 * 100n) / 10000n;
expect(auctioneerBalanceAfter - auctioneerBalanceBefore).to.equal(bid3 - protocolFee);
```

## Testing

- ✅ All 37 tests now passing (previously 35 passing, 2 failing)
- ✅ Verified token accounting matches expected balances
- ✅ Auctioneer withdrawals complete successfully

## Related Issues

Closes #30 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined refund logic in the bid revelation process to prevent refunds to auctioneers under specific conditions.
  * Introduced a 1% protocol fee deducted from proceeds when auctioneers withdraw auction winnings.

* **Tests**
  * Updated test suite to verify protocol fee calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->