### PR TITLE
In AllPayAuction.sol and EnglishAuction.sol, the withdraw functions are external so must be secured

### DIFF
--- a/contracts/AllPayAuction.sol
+++ b/contracts/AllPayAuction.sol
@@ -106,6 +106,7 @@ contract AllPayAuction is Auction {
 
     function withdraw(uint256 auctionId) external exists(auctionId) {
         AuctionData storage auction = auctions[auctionId];
+        require(msg.sender == auction.auctioneer, "Only auctioneer can withdraw");
         uint256 withdrawAmount = auction.availableFunds;
         auction.availableFunds = 0;
         uint256 fees = (auction.protocolFee * withdrawAmount) / 10000;

--- a/contracts/EnglishAuction.sol
+++ b/contracts/EnglishAuction.sol
@@ -109,6 +109,7 @@ contract EnglishAuction is Auction {
 
     function withdraw(uint256 auctionId) external exists(auctionId) onlyAfterDeadline(auctions[auctionId].deadline) {
         AuctionData storage auction = auctions[auctionId];
+        require(msg.sender == auction.auctioneer, "Only auctioneer can withdraw");
         uint256 withdrawAmount = auction.availableFunds;
         auction.availableFunds = 0;
         uint256 fees = (auction.protocolFee * withdrawAmount) / 10000;


### PR DESCRIPTION
In AllPayAuction.sol and EnglishAuction.sol, the withdraw functions are external but do not verify that the msg.sender is the auctioneer.

Issue: Anyone can trigger the withdrawal of funds to the auctioneer's address.

Risk: While the funds go to the correct person (the auctioneer), this allows external parties to force financial realizations for the auctioneer, which might have tax or accounting implications, or interfere with a manager's planned strategy.

Fix: Add require(msg.sender == auction.auctioneer) to the withdraw functions.

Closes #21 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Added authorization verification to withdrawal operations in auction contracts to restrict fund withdrawals to authorized parties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->