### PR TITLE
fix: reject zero-value bids in bid()

### DIFF
--- a/contracts/EnglishAuction.sol
+++ b/contracts/EnglishAuction.sol
@@ -92,6 +92,7 @@ contract EnglishAuction is Auction {
 
     function bid(uint256 auctionId, uint256 bidAmount) external exists(auctionId) beforeDeadline(auctions[auctionId].deadline) {
         AuctionData storage auction = auctions[auctionId];
+        require(bidAmount > 0, "Bid amount must be greater than zero");
         require(auction.highestBid != 0 || bidAmount >= auction.minimumBid, 'First bid should be greater than starting bid');
         require(auction.highestBid == 0 || bidAmount >= auction.highestBid + auction.minBidDelta, 'Bid amount should exceed current bid by atleast minBidDelta');
         receiveERC20(auction.biddingToken, msg.sender, bidAmount);

--- a/test/EnglishAuction.test.ts
+++ b/test/EnglishAuction.test.ts
@@ -182,6 +182,38 @@ describe('EnglishAuction', function () {
             expect(auction.highestBid).to.equal(bidAmount);
         });
 
+        it('should revert zero bid when minimumBid is greater than zero', async function () {
+            const auction = await englishAuction.auctions(0);
+            expect(auction.minimumBid).to.be.gt(0);
+
+            await expect(englishAuction.connect(bidder1).bid(0, 0)).to.be.revertedWith('Bid amount must be greater than zero');
+        });
+
+        it('should revert zero bid when minimumBid is zero', async function () {
+            const auctionedAmount = ethers.parseEther('10');
+            await mockToken.connect(auctioneer).approve(await englishAuction.getAddress(), auctionedAmount);
+            await englishAuction
+                .connect(auctioneer)
+                .createAuction(
+                    'Zero Min Bid Auction',
+                    'Test Description',
+                    'https://example.com/test.jpg',
+                    1,
+                    await mockToken.getAddress(),
+                    auctionedAmount,
+                    await biddingToken.getAddress(),
+                    0,
+                    ethers.parseEther('0.1'),
+                    5,
+                    10,
+                );
+
+            const auction = await englishAuction.auctions(1);
+            expect(auction.minimumBid).to.equal(0);
+
+            await expect(englishAuction.connect(bidder1).bid(1, 0)).to.be.revertedWith('Bid amount must be greater than zero');
+        });
+
         it('should extend deadline on bid', async function () {
             const beforeBid = (await englishAuction.auctions(0)).deadline;
 


### PR DESCRIPTION
###  Addressed Issues:

Fixes #65 

- Added an early revert in `contracts/EnglishAuction.sol` inside `bid(uint256 auctionId, uint256 bidAmount)` immediately after:
  `AuctionData storage auction = auctions[auctionId];`
- New check:
  `require(bidAmount > 0, "Bid amount must be greater than zero");`

###  Screenshots/Recordings:

<img width="860" height="567" alt="image" src="https://github.com/user-attachments/assets/3c31c3f5-79c0-425e-9da8-324439724049" />



###  Additional Notes:
<!-- Add any additional information, context, or notes for reviewers -->

### AI Usage Disclosure:

We encourage contributors to use AI tools responsibly when creating Pull Requests. While AI can be a valuable aid, it is essential to ensure that your contributions meet the task requirements, build successfully, include relevant tests, and pass all linters. Submissions that do not meet these standards may be closed without warning to maintain the quality and integrity of the project. Please take the time to understand the changes you are proposing and their impact. AI slop is strongly discouraged and may lead to banning and blocking. Do not spam our repos with AI slop.

Check one of the checkboxes below:

- [x] This PR does not contain AI-generated code at all.
- [ ] This PR contains AI-generated code. I have read the [AI Usage Policy](https://github.com/AOSSIE-Org/Info/blob/main/AI-UsagePolicy.md) and this PR complies with this policy. I have tested the code locally and I am responsible for it.

I have used the following AI models and tools: TODO


## Checklist
<!-- Mark items with [x] to indicate completion -->
- [x] My PR addresses a single issue, fixes a single bug or makes a single improvement.
- [x] My code follows the project's code style and conventions
- [x] If applicable, I have made corresponding changes or additions to the documentation
- [x] If applicable, I have made corresponding changes or additions to tests
- [x] My changes generate no new warnings or errors
- [x] I have joined the [Discord server](https://discord.gg/hjUhu33uAn) and I will share a link to this PR with the project maintainers there
- [x] I have read the [Contribution Guidelines](../CONTRIBUTING.md)
- [x] Once I submit my PR, CodeRabbit AI will automatically review it and I will address CodeRabbit's comments.
- [x] I have filled this PR template completely and carefully, and I understand that my PR may be closed without review otherwise.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced bid validation to reject zero-value bids, preventing invalid auction interactions and improving contract robustness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->